### PR TITLE
make module/grafana permission work again in icingaweb2 >2.4.0

### DIFF
--- a/run.php
+++ b/run.php
@@ -1,4 +1,4 @@
 <?php
 
-$this->registerHook('grapher', '\\Icinga\\Module\\Grafana\\Grapher');
+$this->registerHook('grapher', 'Icinga\\Module\\Grafana\\Grapher');
 


### PR DESCRIPTION
workaround for https://github.com/Icinga/icingaweb2/issues/2650, possibly needs to be reverted when the issue in icingaweb2 is solved. 